### PR TITLE
Name filters, line ending preservation, etc.

### DIFF
--- a/misspell_fixer.sh
+++ b/misspell_fixer.sh
@@ -86,6 +86,10 @@ while getopts ":dvrfsinuhN:" opt; do
 	esac
 done
 
+if [ -n "$opt_name_filter" ]; then
+	opt_name_filter='-true'
+fi
+
 shift $((OPTIND-1))
 
 if [[ "$@" = "" ]]


### PR DESCRIPTION
Added a few new features:
- Name filters for the 'find' command. Allows you do to a selective
  correction to say, .cpp and .h files only. (-N <filter> switch)
- Told sed to not mess with line endings (-b). Useful for Windows (MinGW)

Usage example:

./misspell_fixer.sh -f -n -r -N *.cpp -N *.h /c/foo/bar/baz
