### PR TITLE
Use more portable shebang for finding bash

### DIFF
--- a/misspell_fixer.sh
+++ b/misspell_fixer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function warning {
 	echo "misspell_fixer: $@">&2


### PR DESCRIPTION
Fixes `bad interpreter: /bin/bash: no such file or directory` on FreeBSD