### PR TITLE
Exclude some binary files from checking

### DIFF
--- a/misspell_fixer.sh
+++ b/misspell_fixer.sh
@@ -35,7 +35,7 @@ function init_variables {
 	export cmd_part_rules="-f $rules_safe0"
 
 	export cmd_part_ignore_scm=" ! -wholename *.git* ! -wholename *.svn* ! -wholename *.hg* "
-	export cmd_part_ignore_bin=" ! -iwholename *.gif ! -iwholename *.jpg ! -iwholename *.png ! -iwholename *.zip ! -iwholename *.gz ! -iwholename *.bz2 ! -iwholename *.rar ! -iwholename *.po "
+	export cmd_part_ignore_bin=" ! -iwholename *.gif ! -iwholename *.jpg ! -iwholename *.png ! -iwholename *.zip ! -iwholename *.gz ! -iwholename *.bz2 ! -iwholename *.xz ! -iwholename *.rar ! -iwholename *.po ! -iwholename *.pdf ! -iwholename *.woff ! -iwholename *.woff2 "
 	export cmd_part_ignore
 
 	export opt_name_filter=''


### PR DESCRIPTION
*.xz,  *.pdf,  *.woff, *.woff2
(From: https://github.com/moisseev/misspell_fixer/commit/65834652fddfb250c4b812ff08542b259cb8fde9)